### PR TITLE
Workaround for Windows installation error.

### DIFF
--- a/contrib/install-plugin-deps.js
+++ b/contrib/install-plugin-deps.js
@@ -11,5 +11,6 @@ fs.readdirSync(lib).forEach(function (mod) {
 	// ensure path has package.json
 	if (!fs.existsSync(join(modPath, 'package.json'))) return;
 	// install folder
-	cp.spawn('npm', ['install'], { env: process.env, cwd: modPath, stdio: 'inherit' });
+	var command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+	cp.spawn(command, ['install'], { env: process.env, cwd: modPath, stdio: 'inherit' });
 });


### PR DESCRIPTION
- Fixed Windows installation error, "spawn npm ENOENT".